### PR TITLE
Add Average Attention Network in Transformer Decoder

### DIFF
--- a/onmt/decoders/transformer.py
+++ b/onmt/decoders/transformer.py
@@ -144,7 +144,7 @@ class TransformerDecoder(nn.Module):
     """
 
     def __init__(self, num_layers, hidden_size, attn_type,
-                 copy_attn, average_attn, dropout, embeddings):
+                 copy_attn, self_attn_type, dropout, embeddings):
         super(TransformerDecoder, self).__init__()
 
         # Basic attributes.
@@ -153,14 +153,9 @@ class TransformerDecoder(nn.Module):
         self.embeddings = embeddings
 
         # Build TransformerDecoder.
-        if average_attn:
-            self.transformer_layers = nn.ModuleList(
-                [TransformerDecoderLayer(hidden_size, dropout, self_attn_type="average")
-                 for _ in range(num_layers)])
-        else:
-            self.transformer_layers = nn.ModuleList(
-                [TransformerDecoderLayer(hidden_size, dropout, self_attn_type="scaled-dot")
-                 for _ in range(num_layers)])
+        self.transformer_layers = nn.ModuleList(
+            [TransformerDecoderLayer(hidden_size, dropout, self_attn_type=self_attn_type)
+             for _ in range(num_layers)])
 
         # TransformerDecoder has its own attention mechanism.
         # Set up a separated copy attention layer, if needed.

--- a/onmt/decoders/transformer.py
+++ b/onmt/decoders/transformer.py
@@ -26,10 +26,17 @@ class TransformerDecoderLayer(nn.Module):
     """
 
     def __init__(self, size, dropout,
-                 head_count=8, hidden_size=2048):
+                 head_count=8, hidden_size=2048, self_attn_type="scaled-dot"):
         super(TransformerDecoderLayer, self).__init__()
-        self.self_attn = onmt.modules.MultiHeadedAttention(
-            head_count, size, dropout=dropout)
+
+        self.self_attn_type = self_attn_type
+
+        if self_attn_type == "scaled-dot":
+            self.self_attn = onmt.modules.MultiHeadedAttention(
+                head_count, size, dropout=dropout)
+        elif self_attn_type == "average":
+            self.self_attn = onmt.modules.AverageAttention(
+                size, dropout=dropout)
         self.context_attn = onmt.modules.MultiHeadedAttention(
             head_count, size, dropout=dropout)
         self.feed_forward = PositionwiseFeedForward(size,
@@ -45,7 +52,7 @@ class TransformerDecoderLayer(nn.Module):
         self.register_buffer('mask', mask)
 
     def forward(self, inputs, memory_bank, src_pad_mask, tgt_pad_mask,
-                previous_input=None):
+                previous_input=None, layer_cache=None, step=None):
         # Args Checks
         input_batch, input_len, _ = inputs.size()
         if previous_input is not None:
@@ -71,8 +78,14 @@ class TransformerDecoderLayer(nn.Module):
         if previous_input is not None:
             all_input = torch.cat((previous_input, input_norm), dim=1)
             dec_mask = None
-        query, attn = self.self_attn(all_input, all_input, input_norm,
-                                     mask=dec_mask)
+
+        if self.self_attn_type == "scaled-dot":
+            query, attn = self.self_attn(all_input, all_input, input_norm,
+                                             mask=dec_mask)
+        elif self.self_attn_type == "average":
+            query, attn = self.self_attn(input_norm,
+                                             mask=dec_mask, layer_cache=layer_cache, step=step)
+
         query = self.drop(query) + inputs
 
         query_norm = self.layer_norm_2(query)
@@ -131,7 +144,7 @@ class TransformerDecoder(nn.Module):
     """
 
     def __init__(self, num_layers, hidden_size, attn_type,
-                 copy_attn, dropout, embeddings):
+                 copy_attn, average_attn, dropout, embeddings):
         super(TransformerDecoder, self).__init__()
 
         # Basic attributes.
@@ -140,9 +153,14 @@ class TransformerDecoder(nn.Module):
         self.embeddings = embeddings
 
         # Build TransformerDecoder.
-        self.transformer_layers = nn.ModuleList(
-            [TransformerDecoderLayer(hidden_size, dropout)
-             for _ in range(num_layers)])
+        if average_attn:
+            self.transformer_layers = nn.ModuleList(
+                [TransformerDecoderLayer(hidden_size, dropout, self_attn_type="average")
+                 for _ in range(num_layers)])
+        else:
+            self.transformer_layers = nn.ModuleList(
+                [TransformerDecoderLayer(hidden_size, dropout, self_attn_type="scaled-dot")
+                 for _ in range(num_layers)])
 
         # TransformerDecoder has its own attention mechanism.
         # Set up a separated copy attention layer, if needed.
@@ -153,7 +171,17 @@ class TransformerDecoder(nn.Module):
             self._copy = True
         self.layer_norm = onmt.modules.LayerNorm(hidden_size)
 
-    def forward(self, tgt, memory_bank, state, memory_lengths=None):
+
+    def _init_cache(self, memory_bank, memory_lengths=None):
+        cache = {}
+        batch_size = memory_bank.size(1)
+        depth = memory_bank.size(-1)
+        for l in range(self.num_layers):
+            layer_cache = {"prev_g": torch.zeros((batch_size, 1, depth))}
+            cache["layer_{}".format(l)] = layer_cache
+        return cache
+
+    def forward(self, tgt, memory_bank, state, memory_lengths=None, step=None, cache=None):
         """
         See :obj:`onmt.modules.RNNDecoderBase.forward()`
         """
@@ -197,6 +225,7 @@ class TransformerDecoder(nn.Module):
             .expand(tgt_batch, tgt_len, tgt_len)
 
         saved_inputs = []
+
         for i in range(self.num_layers):
             prev_layer_input = None
             if state.previous_input is not None:
@@ -204,7 +233,9 @@ class TransformerDecoder(nn.Module):
             output, attn, all_input \
                 = self.transformer_layers[i](output, src_memory_bank,
                                              src_pad_mask, tgt_pad_mask,
-                                             previous_input=prev_layer_input)
+                                             previous_input=prev_layer_input,
+                                             layer_cache=cache["layer_{}".format(i)] if cache is not None else None,
+                                             step=step)
             saved_inputs.append(all_input)
 
         saved_inputs = torch.stack(saved_inputs)

--- a/onmt/model_builder.py
+++ b/onmt/model_builder.py
@@ -93,6 +93,7 @@ def build_decoder(opt, embeddings):
     if opt.decoder_type == "transformer":
         return TransformerDecoder(opt.dec_layers, opt.rnn_size,
                                   opt.global_attention, opt.copy_attn,
+                                  opt.average_attn,
                                   opt.dropout, embeddings)
     elif opt.decoder_type == "cnn":
         return CNNDecoder(opt.dec_layers, opt.rnn_size,

--- a/onmt/model_builder.py
+++ b/onmt/model_builder.py
@@ -93,7 +93,7 @@ def build_decoder(opt, embeddings):
     if opt.decoder_type == "transformer":
         return TransformerDecoder(opt.dec_layers, opt.rnn_size,
                                   opt.global_attention, opt.copy_attn,
-                                  opt.average_attn,
+                                  opt.self_attn_type,
                                   opt.dropout, embeddings)
     elif opt.decoder_type == "cnn":
         return CNNDecoder(opt.dec_layers, opt.rnn_size,

--- a/onmt/modules/__init__.py
+++ b/onmt/modules/__init__.py
@@ -7,8 +7,9 @@ from onmt.modules.copy_generator import CopyGenerator, CopyGeneratorLossCompute
 from onmt.modules.multi_headed_attn import MultiHeadedAttention
 from onmt.modules.embeddings import Embeddings, PositionalEncoding
 from onmt.modules.weight_norm import WeightNormConv2d
+from onmt.modules.average_attn import AverageAttention
 
 __all__ = ["LayerNorm", "Elementwise", "context_gate_factory", "ContextGate",
            "GlobalAttention", "ConvMultiStepAttention", "CopyGenerator",
            "CopyGeneratorLossCompute", "MultiHeadedAttention", "Embeddings",
-           "PositionalEncoding", "WeightNormConv2d"]
+           "PositionalEncoding", "WeightNormConv2d", "AverageAttention"]

--- a/onmt/modules/average_attn.py
+++ b/onmt/modules/average_attn.py
@@ -1,0 +1,88 @@
+""" Multi-Head Attention module """
+import math
+import torch
+import torch.nn as nn
+from torch.autograd import Variable
+import numpy as np
+
+from onmt.utils.misc import aeq
+
+from onmt.utils.transformer_util import PositionwiseFeedForward
+
+
+class AverageAttention(nn.Module):
+    """
+    Average Attention module from
+    "Accelerating Neural Transformer via an Average Attention Network"
+    :cite:`https://arxiv.org/abs/1805.00631`.
+
+    Args:
+       model_dim (int): the dimension of keys/values/queries,
+           must be divisible by head_count
+       dropout (float): dropout parameter
+    """
+
+    def __init__(self, model_dim, dropout=0.1):
+        self.model_dim = model_dim
+
+        super(AverageAttention, self).__init__()
+
+        self.average_layer = PositionwiseFeedForward(model_dim, model_dim, dropout)
+        self.gating_layer = nn.Linear(model_dim * 2, model_dim * 2)
+
+
+    def cumulative_average_mask(self, batch_size, inputs_len):
+          """
+          Builds the mask to compute the cumulative average as described in
+          https://arxiv.org/abs/1805.00631 -- Figure 3
+
+          Args:
+            inputs_len: length of the inputs.
+
+          Returns:
+            A Tensor of shape [batch_size, input_len, input_len]
+          """
+
+          triangle = np.tril(np.ones((inputs_len, inputs_len)))
+          weights = np.ones((1, inputs_len)) / np.arange(1, inputs_len + 1)
+          mask = torch.from_numpy(triangle * weights.T)
+
+          return mask.unsqueeze(0).expand(batch_size, inputs_len, inputs_len)
+
+    def cumulative_average(self, inputs, mask_or_step, layer_cache=None, step=None):
+      """
+      Computes the cumulative average as described in
+      https://arxiv.org/abs/1805.00631 -- Equations (1) (5) (6)
+
+      Args:
+        inputs: sequence to average -- Tensor of shape [batch_size, input_len, dimension]
+        mask_or_step: if cache is set, this is assumed to be the current step of the
+          dynamic decoding. Otherwise, it is the mask matrix used to compute the cumulative average.
+        cache: a dictionary containing the cumulative average of the previous step.
+      """
+      if layer_cache is not None:
+        step = mask_or_step
+        device = inputs.device
+        average_attention = (inputs + step * layer_cache["prev_g"].to(device)) / (step + 1)
+        layer_cache["prev_g"] = average_attention
+        return average_attention
+      else:
+        mask = mask_or_step
+        return torch.matmul(mask, inputs)
+
+    def forward(self, inputs, mask=None, layer_cache=None, step=None):
+
+        batch_size = inputs.size(0)
+        inputs_len = inputs.size(1)
+
+        device = inputs.device
+        average_outputs = self.cumulative_average(inputs,
+          self.cumulative_average_mask(batch_size, inputs_len).to(device).float() if layer_cache is None else step,
+          layer_cache=layer_cache)
+        average_outputs = self.average_layer(average_outputs)
+        concat = torch.cat((inputs, average_outputs), -1)
+        gating_outputs = self.gating_layer(torch.cat((inputs, average_outputs), -1))
+        input_gate, forget_gate = torch.split(gating_outputs, int(gating_outputs.size(2)/2), dim=2)
+        gating_outputs = torch.sigmoid(input_gate) * inputs + torch.sigmoid(forget_gate) * average_outputs
+
+        return gating_outputs, None

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -107,6 +107,9 @@ def model_opts(parser):
                        choices=['dot', 'general', 'mlp'],
                        help="""The attention type to use:
                        dotprod or general (Luong) or MLP (Bahdanau)""")
+    group.add_argument('-average_attn', action='store_true',
+                       help="""Replace multi-head attention with average
+                       average attention network in transformer decoder""")
 
     # Genenerator and loss options.
     group.add_argument('-copy_attn', action="store_true",
@@ -357,7 +360,7 @@ def train_opts(parser):
                        validation set or (ii) steps have gone past
                        start_decay_steps""")
     group.add_argument('-start_decay_steps', type=int, default=50000,
-                       help="""Start decaying every decay_steps after 
+                       help="""Start decaying every decay_steps after
                        start_decay_steps""")
     group.add_argument('-decay_steps', type=int, default=10000,
                        help="""Decay every decay_steps""")

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -107,9 +107,9 @@ def model_opts(parser):
                        choices=['dot', 'general', 'mlp'],
                        help="""The attention type to use:
                        dotprod or general (Luong) or MLP (Bahdanau)""")
-    group.add_argument('-average_attn', action='store_true',
-                       help="""Replace multi-head attention with average
-                       average attention network in transformer decoder""")
+    group.add_argument('-self_attn_type', type=str, default="scaled-dot",
+                       help="""Self attention type in Transformer decoder
+                       layer -- currently "scaled-dot" or "average" """)
 
     # Genenerator and loss options.
     group.add_argument('-copy_attn', action="store_true",

--- a/onmt/translate/translator.py
+++ b/onmt/translate/translator.py
@@ -4,7 +4,7 @@ import argparse
 import codecs
 import os
 import math
-
+import time
 import torch
 from itertools import count
 
@@ -42,7 +42,7 @@ def build_translator(opt, report_score=True, out_file=None):
     translator = Translator(model, fields, global_scorer=scorer,
                             out_file=out_file, report_score=report_score,
                             copy_attn=model_opt.copy_attn,
-                            average_attn=model_opt.average_attn, **kwargs)
+                            self_attn_type=model_opt.self_attn_type, **kwargs)
     return translator
 
 
@@ -73,7 +73,7 @@ class Translator(object):
                  max_length=100,
                  global_scorer=None,
                  copy_attn=False,
-                 average_attn=False,
+                 self_attn_type="scaled-dot",
                  gpu=False,
                  dump_beam="",
                  min_length=0,
@@ -102,7 +102,7 @@ class Translator(object):
         self.max_length = max_length
         self.global_scorer = global_scorer
         self.copy_attn = copy_attn
-        self.average_attn = average_attn
+        self.self_attn_type = self_attn_type
         self.beam_size = beam_size
         self.min_length = min_length
         self.stepwise_penalty = stepwise_penalty
@@ -328,7 +328,7 @@ class Translator(object):
         dec_states.repeat_beam_size_times(beam_size)
 
         # initialize cache
-        if self.average_attn:
+        if self.self_attn_type == "average":
           cache = self.model.decoder._init_cache(memory_bank, memory_lengths=memory_lengths)
         else:
           cache = None
@@ -354,7 +354,7 @@ class Translator(object):
             inp = inp.unsqueeze(2)
 
             # Run one step.
-            if self.average_attn:
+            if self.self_attn_type == "average":
               dec_out, dec_states, attn = self.model.decoder(
                   inp, memory_bank, dec_states, memory_lengths=memory_lengths, step=i, cache=cache)
             else:
@@ -381,11 +381,13 @@ class Translator(object):
                 # beam x tgt_vocab
                 out = out.log()
                 beam_attn = unbottle(attn["copy"])
+
             # (c) Advance each beam.
             for j, b in enumerate(beam):
                 b.advance(out[:, j],
                           beam_attn.data[:, j, :memory_lengths[j]])
                 dec_states.beam_update(j, b.get_current_origin(), beam_size)
+
 
         # (4) Extract sentences from beam.
         ret = self._from_beam(beam)


### PR DESCRIPTION
Self attention layer in Transformer Decoder is replaced by an Average Attention Network (instead of Multi Head Attention) if the option `-average_attn` is added to the train command.

Still need to implement decoder cache.
And possibly better structure the library (abstract class Decoder, which every decoder would inherit from) to prevent passing step / cache in arguments and some conditionals.